### PR TITLE
Enable the use of Unitful.jl quantities as the element type of moment tensors.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,8 +1,6 @@
 environment:
   matrix:
-    - julia_version: 0.7
     - julia_version: 1.0
-    - julia_version: 1.1
     - julia_version: 1
     - julia_version: nightly
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ os:
   - osx
   - linux
 julia:
-  - 0.7
   - 1.0
-  - 1.1
-  - 1.2
+  - 1.5
   - nightly
 notifications:
   email: false

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MomentTensors"
 uuid = "7bb32750-d21c-11e8-1ebc-09158bc70490"
 authors = ["Andy Nowacki <a.nowacki@leeds.ac.uk>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -9,7 +9,7 @@ Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-julia = "0.7, 1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -3,16 +3,17 @@ uuid = "7bb32750-d21c-11e8-1ebc-09158bc70490"
 authors = ["Andy Nowacki <a.nowacki@leeds.ac.uk>"]
 version = "0.2.4"
 
-[compat]
-julia = "0.7, 1"
-
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[compat]
+julia = "0.7, 1"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Unitful"]

--- a/src/MomentTensors.jl
+++ b/src/MomentTensors.jl
@@ -83,7 +83,7 @@ One may access the values of a moment tensor `M` in two ways:
 1. M[i,j] yields the elements of `M.m` as if they were a two-tensor
 2. M[::Symbol] yields the elements by name; see `getindex` for details
 """
-struct MT{T<:AbstractFloat}
+struct MT{T<:Number}
     m::SVector{6,T}
     MT{T}(m) where T = new{T}(m)
 end
@@ -128,18 +128,19 @@ Base.getindex(m::MT, i, j) = m.m[_ij2k[i,j]]
 Base.getindex(m::MT, i, j, inds...) = m[inds[i],inds[j]][inds...]
 Base.size(m::MT) = (3, 3)
 Base.isapprox(m1::MT, m2::MT; kwargs...) = isapprox(m1.m, m2.m; kwargs...)
+Base.eltype(::MT{T}) where T = T
 
-Base.:+(m::MT, a::Real) = MT(m.m .+ a)
-Base.:+(a::Real, m::MT) = MT(a .+ m.m)
+Base.:+(m::MT, a::Number) = MT(m.m .+ a)
+Base.:+(a::Number, m::MT) = MT(a .+ m.m)
 Base.:+(a::MT, b::MT) = MT(a.m .+ b.m)
-Base.:-(m::MT, a::Real) = MT(m.m .- a)
-Base.:-(a::Real, m::MT) = MT(a .- m.m)
+Base.:-(m::MT, a::Number) = MT(m.m .- a)
+Base.:-(a::Number, m::MT) = MT(a .- m.m)
 Base.:-(a::MT, b::MT) = MT(a.m .- b.m)
 Base.:-(m::MT) = MT(-m.m)
-Base.:*(m::MT, a::Real) = MT(m.m.*a)
-Base.:*(a::Real, m::MT) = MT(a.*m.m)
-Base.:/(m::MT, a::Real) = MT(m.m./a)
-Base.:/(a::Real, m::MT) = MT(a./m.m)
+Base.:*(m::MT, a::Number) = MT(m.m.*a)
+Base.:*(a::Number, m::MT) = MT(a.*m.m)
+Base.:/(m::MT, a::Number) = MT(m.m./a)
+Base.:/(a::Number, m::MT) = MT(a./m.m)
 
 # Routines using or manipulating MTs
 """

--- a/test/construction.jl
+++ b/test/construction.jl
@@ -4,6 +4,10 @@ using MomentTensors, Test, StaticArrays
     @testset "Direct" begin
         @test MT(1, 2, 3, 4, 5, 6) isa MT{Float64}
         @test MT{Float32}(1, 2, 3, 4, 5, 6) isa MT{Float32}
+        @testset "$T" for T in (Float32, Float64)
+            @test eltype(MT{T}(1, 2, 3, 4, 5, 6)) == T
+            @test eltype(MT{Complex{T}}(1, 2, 3, 4, 5, 6)) == Complex{T}
+        end
         @test MT(1, 2, 3, 4, 5, 6) == MT(@SVector[1, 2, 3, 4, 5, 6])
         @test MT(Int32[1, 2, 3, 4, 5, 6]) ==
             MT{float(Int32)}(@SVector[1.f0, 2.f0, 3.f0, 4.f0, 5.f0, 6.f0])

--- a/test/decompose.jl
+++ b/test/decompose.jl
@@ -1,4 +1,4 @@
-using MomentTensors, Test
+using MomentTensors, Test, StaticArrays
 
 # Comparison with example at http://www.larskrieger.de/mopad/#getall
 @testset "Decomposition" begin
@@ -23,5 +23,10 @@ using MomentTensors, Test
         @test d.m0 ≈ 14.9031089939
         @test mw(d.m0) ≈ -5.25114874821
         @test eps_non_dc(m) ≈ -0.34250995536253115
+    end
+
+    @testset "_sortperm_abs_3" begin
+        @test MomentTensors._sortperm_abs_3(SVector(1.0, 2.0, 3.0)) == SVector(1, 2, 3)
+        @test MomentTensors._sortperm_abs_3(SVector(-3.0, -2.0, 1)) == SVector(3, 2, 1)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,4 +8,5 @@ using MomentTensors, Test
     include("planes.jl")
     include("io.jl")
     include("decompose.jl")
+    include("units.jl")
 end

--- a/test/units.jl
+++ b/test/units.jl
@@ -1,0 +1,92 @@
+# MTs with eltypes which have units from the Unitful package
+
+using Test
+using MomentTensors
+using Unitful
+
+@testset "Units" begin
+    m = Unitful.m
+    N = Unitful.N
+    Nm = N*m
+
+    @testset "Construction" begin
+        @test MT((1, 2, 3, 4, 5, 6).*u"N*m") == MT(1Nm, 2Nm, 3Nm, 4Nm, 5Nm, 6Nm) == MT((1:6)*Nm)
+        @test MT(1:6) != MT((1:6)*Nm)
+        let mt = MT((1:6)*Nm)
+            @test eltype(mt) == typeof(float(1Nm))
+        end
+    end
+
+    @testset "getindex/setindex!" begin
+        let mt = MT((1:6)*Nm)
+            @test mt[1,1] == 1Nm
+        end
+    end
+
+    @testset "Arithmetic" begin
+        @test MT(ones(6).*u"N*m/s") + MT(2*ones(6).*u"N*m/s") == MT(3*ones(6).*u"N*m/s")
+        let m1 = MT((11, 22, 33, 12, 13, 23).*Nm),
+            m2 = MT((-11, -22, -33, -12, -13, -23).*Nm)
+            @test m1 + m2 == MT((0, 0, 0, 0, 0, 0).*Nm)
+            @test m1 == -m2
+            @test -m1 == m2
+            @test m1 + 1Nm == MT((12, 23, 34, 13, 14, 24).*Nm)
+            @test m1 - 1Nm == MT((10, 21, 32, 11, 12, 22).*Nm)
+            @test m1 + 3Nm == 3Nm + m1
+            @test m1 - 4Nm == -(4Nm - m1)
+            @test 2m1 == MT((22, 44, 66, 24, 26, 46).*Nm)
+            @test 2m1 == m1*2
+            @test 1/m1 == MT(1 ./ ((11, 22, 33, 12, 13, 23).*Nm)...)
+            @test m1/2 == MT((5.5, 11, 16.5, 6, 6.5, 11.5).*Nm)
+        end
+    end
+
+    @testset "Conversion" begin
+        @test Array(MT((1:6)*Nm)) == Float64[1 4 5; 4 2 6; 5 6 3].*Nm
+    end
+
+    @testset "Decomposition" begin
+        let m = MT([ 3 -5 10
+                    -5  1  4
+                    10  4  1].*Nm)
+            eltp = typeof(float(1Nm))
+            d = decompose(m)
+
+            @testset "Unitful MT $f" for f in (:iso, :dev, :dc, :clvd)
+                @test eltype(getfield(d, f)) == eltp
+            end
+            @testset "Unitful scalar $f" for f in (:iso_m0, :dev_m0, :m0)
+                @test typeof(getfield(d, f)) == eltp
+            end
+            @testset "Dimensionless scalar $f" for f in (:prop_iso, :prop_dev, :prop_dc, :prop_clvd)
+                @test typeof(getfield(d, f)) == typeof(ustrip(m[1,1]))
+            end
+        end
+    end
+
+    @testset "amplitude_v_azimuth" begin
+        eltp = typeof(Float32(1N))
+        p, sv, sh, j = amplitude_v_azimuth(MT(rand(Float32, 6).*N), 0, 0)
+        for v in (p, sv, sh)
+            @test eltype(v) == eltp
+        end
+        @test eltype(j) == Float32
+    end
+
+    @testset "radiation_pattern" begin
+        eltp = typeof(Float32(1Nm))
+        p, sv, sh, j = radiation_pattern(MT(rand(Float32, 6).*Nm), 0, 0)
+        for v in (p, sv, sh)
+            @test v isa eltp
+        end
+        @test j isa Float32
+    end
+
+    @testset "rotate" begin
+        @test rotate(MT(rand(Float32, 6).*Nm), 1, 2, 3) isa MT{typeof(1f0*Nm)}
+    end
+
+    @testset "eps_non_dc" begin
+        @test eps_non_dc(MT(rand(Float32, 6).*Nm)) isa typeof(ustrip(1f0*Nm))
+    end
+end


### PR DESCRIPTION
Almost all functions now correctly propagate the
element type, with the exception of `m0` and `Mw`.
(Hard to fathom how this could be done without
depending on Unitful, which I want to avoid.)